### PR TITLE
Fix visualizer child process using stale PyInstaller temp paths

### DIFF
--- a/python_app/main.py
+++ b/python_app/main.py
@@ -1337,7 +1337,14 @@ class RGBControllerApp(QMainWindow):
                     self.kb = None
 
                 env = os.environ.copy()
-                env['PYTHONPATH'] = os.pathsep.join(sys.path)
+                # Avoid propagating stale PyInstaller extraction paths to child
+                # processes. If the parent exits and removes its _MEI folder,
+                # inherited _MEIPASS values can make the child look for
+                # python*.dll in a deleted temp directory.
+                env.pop('_MEIPASS', None)
+                env.pop('_MEIPASS2', None)
+                if not getattr(sys, 'frozen', False):
+                    env['PYTHONPATH'] = os.pathsep.join(sys.path)
                 sensitivity_val  = str(self.speed_slider.value())
                 smoothness_val   = str(self.bright_slider.value())
                 flicker_val      = str(0)


### PR DESCRIPTION
### Motivation

- Child visualizer processes could inherit PyInstaller extraction environment variables (`_MEIPASS` / `_MEIPASS2`) that point at a deleted `%TEMP%\_MEI*` folder and then fail trying to load `python*.dll` from that removed location.
- The app intentionally uses the Temp folder for updates (`4_Zone_Rgb_Toolkit_Updated.exe`, `updater.ps1`) and the updater/cleanup code may remove those files, making stale env vars a real race condition.

### Description

- Sanitize the environment passed to the audio visualizer subprocess by removing `_MEIPASS` and `_MEIPASS2` before launching the child process in `python_app/main.py`.
- Only set `PYTHONPATH` for non-frozen (development) runs so bundled executables do not inherit `PYTHONPATH` that could confuse resolution.
- Changes applied to the visualizer launch code-path around where `env = os.environ.copy()` and committed with the message `Fix stale PyInstaller temp env when launching visualizer`.

### Testing

- Ran `python -m py_compile python_app/main.py` to validate syntax and it completed successfully.
- Performed repository checks (`rg`/`sed`) to verify the modified block exists and contains the environment sanitization and they succeeded.
- Committed the change and ensured the working tree shows the updated `python_app/main.py` file successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f4fc16250832e8521bfdf33fae4be)